### PR TITLE
Set width and height 100% in body and html tag

### DIFF
--- a/static/index.slim
+++ b/static/index.slim
@@ -21,6 +21,10 @@ html
 
     style is="custom-style"
       |
+        html, body {
+          width: 100%;
+          height: 100%;
+        }
         #main-area {
           @apply(--layout-horizontal);
         }


### PR DESCRIPTION
In order to apply correct content size to body and html element,
set width and height 100% in stylesheet.
It solves empty page in printing.

Before:
![screenshot from 2015-09-19 02 36 22](https://cloud.githubusercontent.com/assets/40454/9966343/506f2d74-5e77-11e5-9af4-b0cd791b195b.png)

After:
![screenshot from 2015-09-19 02 35 49](https://cloud.githubusercontent.com/assets/40454/9966346/53356adc-5e77-11e5-8e65-f747f95d8986.png)


And printed pdf
Before:
![screenshot from 2015-09-19 02 37 39](https://cloud.githubusercontent.com/assets/40454/9966370/74a5f7ea-5e77-11e5-8b8e-8c01f15b2f66.png)

After:
![screenshot from 2015-09-19 02 37 53](https://cloud.githubusercontent.com/assets/40454/9966373/794f09ee-5e77-11e5-947c-3bf67297c16b.png)

reference: https://discuss.atom.io/t/webview-autosize/16915/5