### PR TITLE
Use CommandOrControl for Quit App menu item

### DIFF
--- a/browser/menu.ts
+++ b/browser/menu.ts
@@ -18,7 +18,7 @@ export function build(main_window: Electron.BrowserWindow) {
                 },
                 {
                     label: 'Quit App',
-                    accelerator: 'Command+Q',
+                    accelerator: 'CommandOrControl+Q',
                     click: () => main_window.close(),
                 },
                 {


### PR DESCRIPTION
This change will allow Linux and Windows users to quit Shiba with <kbd>Ctrl</kbd> + <kbd>Q</kbd>.

This change will not affect Mac users.

`CommandOrControl` setting is available in [Electron keyboard shortcuts docs](https://github.com/electron/electron/blob/master/docs/api/accelerator.md#available-modifiers)